### PR TITLE
Bump Checkout action

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -6,7 +6,7 @@ jobs:
     if: github.ref == 'refs/heads/master'
     steps:
       - name: checkout
-        uses: actions/checkout@v3.0.0
+        uses: actions/checkout@v4
       - name: build_and_deploy
         uses: shalzz/zola-deploy-action@v0.17.2
         env:


### PR DESCRIPTION
Bumps the Checkout action to the latest, v4, which I've been using widely without issues in other projects.