### PR TITLE
Update CTV and TXHASH use-cases in summary table

### DIFF
--- a/content/overview/summary.md
+++ b/content/overview/summary.md
@@ -15,9 +15,9 @@ toc = false
 
 use case           | apo   | ctv  | txhash | tluv | intro | vault | catt | matt | tplk
 -|-|-|-|-|-|-|-|-|-
-Lightning Symmetry | yes   | no   | yes    | ?    | yes   | no    | yes  | yes  | yes
-Vaults             | no    | no   | tap*   | yes  | tap*  | yes   | yes  | yes  | tap*
-Payment Pools      | no    | no   | tap*   | yes  | tap*  | ~ctv  | yes  | yes  | tap*
+Lightning Symmetry | yes   | ~csfs   | ~csfs    | ?    | yes   | no    | yes  | yes  | yes
+Vaults             | no    | yes   | tap*   | yes  | tap*  | yes   | yes  | yes  | tap*
+Payment Pools      | no    | yes   | tap*   | yes  | tap*  | ~ctv  | yes  | yes  | tap*
 Ark                | half  | half | yes    | no   | yes   | ~ctv  | yes  | yes  | yes
 Fraud Proofs       | no    | no   | no     | no   | no    | no    | no   | yes  | no
 Statechains        | yes   | no   | yes    | ?    | yes   | no    | yes  | yes  | yes
@@ -30,6 +30,7 @@ Glossary:
 - tap*: yes if combined with something that allows turning a script into a Taproot, plus often
   also `OP_CAT`
 - ~ctv: yes but only because the `OP_VAULT` proposal also includes `OP_CTV`
+- ~csfs: yes, but only when it includes OP_CHECKSIGFROMSTACK (CSFS)
 
 
 


### PR DESCRIPTION
Per these tweets, updating the table to properly reflect what CTV supports and specify why TXHASH supports LN-Symmetry:

https://x.com/1440000bytes/status/1736197288970846258?s=20
https://x.com/JeremyRubin/status/1736226209183289742?s=20