### PR TITLE
Update BIP references to reflect merged BIPs and OP_VAULT withdrawal

### DIFF
--- a/content/extra/cat.md
+++ b/content/extra/cat.md
@@ -31,8 +31,7 @@ Script Restoration_](/extra/gsr) project.
 
 ## Specification
 
-A BIP of the `OP_CAT` opcode is currently [in draft status on
-GitHub](https://github.com/bitcoin/bips/pull/1525).
+The `OP_CAT` opcode is specified in [BIP 347](https://github.com/bitcoin/bips/blob/master/bip-0347.mediawiki).
 
 An implementation on Bitcoin Inquisition [is also
 available](https://github.com/bitcoin-inquisition/bitcoin/pull/39).

--- a/content/overview/summary.md
+++ b/content/overview/summary.md
@@ -39,11 +39,11 @@ proposal             | status
 -|-
 ANYPREVOUT           | [BIP][bip118] and active on Inquisition
 CTV                  | [BIP][bip119] and active on Inquisition
-OP_VAULT             | [draft BIP][bip345] and Inquisition [patch][pr-vault]
+OP_VAULT             | [BIP 345][bip345] — Withdrawn (May 2025), superseded by [BIP 443][bip443] (CCV)
 TLUV                 | idea
-TXHASH               | [draft BIP][bip-txhash] and [Bitcoin Core Implementation][pr-txhash]
+TXHASH               | [BIP 346][bip-txhash] and [Bitcoin Core Implementation][pr-txhash]
 Direct Introspection | ideas (but [active on Liquid][intro-liquid])
-MATT                 | very detailed ideas
+MATT                 | [BIP 443][bip443] and [Bitcoin Core Implementation][pr-matt]
 Template Key         | [early draft BIP][bip-template-key]
 
 
@@ -56,11 +56,12 @@ for various proposals, some of them adding a rationale behind their support:
 
 [bip118]: https://github.com/bitcoin/bips/blob/master/bip-0118.mediawiki
 [bip119]: https://github.com/bitcoin/bips/blob/master/bip-0119.mediawiki
-[bip345]: https://github.com/bitcoin/bips/pull/1421
-[bip-txhash]: https://github.com/bitcoin/bips/pull/1500
+[bip345]: https://github.com/bitcoin/bips/blob/master/bip-0345.mediawiki
+[bip443]: https://github.com/bitcoin/bips/blob/master/bip-0443.mediawiki
+[bip-txhash]: https://github.com/bitcoin/bips/blob/master/bip-0346.mediawiki
 [bip-template-key]: https://github.com/reardencode/bips/blob/bip-template-key/bip-template-key.mediawiki
 
 [pr-txhash]: https://github.com/bitcoin/bitcoin/pull/29050
-[pr-vault]: https://github.com/bitcoin-inquisition/bitcoin/pull/21
+[pr-matt]: https://github.com/bitcoin/bitcoin/pull/32080
 
 [intro-liquid]: https://github.com/ElementsProject/elements/blob/master/doc/tapscript_opcodes.md

--- a/content/proposals/catt.md
+++ b/content/proposals/catt.md
@@ -43,11 +43,9 @@ An _extended_ version of CATT can additionally include the following:
 
 The individual pieces of this transaction are specified in different BIPs:
 
-- `OP_TXHASH`: [draft BIP](https://github.com/bitcoin/bips/pull/1500)
-- `OP_CAT`: [draft BIP](https://github.com/EthanHeilman/op_cat_draft/blob/main/cat.mediawiki)
-- `OP_CHECKSIGFROMSTACK`: no BIP yet, but already
-  [implemented](https://github.com/ElementsProject/elements/blob/f08447909101bfbbcaf89e382f55c87b2086198a/src/script/interpreter.cpp#L1399)
-  and active in Elements
+- `OP_TXHASH`: [BIP 346](https://github.com/bitcoin/bips/blob/master/bip-0346.mediawiki)
+- `OP_CAT`: [BIP 347](https://github.com/bitcoin/bips/blob/master/bip-0347.mediawiki)
+- `OP_CHECKSIGFROMSTACK`: [BIP 348](https://github.com/bitcoin/bips/blob/master/bip-0348.mediawiki)
 - `OP_TWEAKVERIFY`: no BIP yet, but already
   [implemented](https://github.com/ElementsProject/elements/blob/c248983aabeba8badf90b2dce36cd35babbe51f6/src/script/interpreter.cpp#L2215)
   and active in Elements

--- a/content/proposals/matt.md
+++ b/content/proposals/matt.md
@@ -11,7 +11,7 @@ toc = true
 
 
 ##### Links
-- [OP_CHECKCONTRACTVERIFY BIP draft](https://github.com/bitcoin/bips/pull/1793)
+- [OP_CHECKCONTRACTVERIFY BIP 443](https://github.com/bitcoin/bips/blob/master/bip-0443.mediawiki)
 - [OP_CHECKCONTRACTVERIFY bitcoin-core implementation](https://github.com/bitcoin/bitcoin/pull/32080)
 - [MATT homepage](https://merkle.fun)
 
@@ -23,7 +23,7 @@ Together with an opcode that allows the creation of _vector commitments_ (like `
 
 ## Specification
 
-The specifications of `OP_CHECKCONTRACTVERIFY` are available in the [OP_CCV BIP draft](https://github.com/bitcoin/bips/pull/1793) and the [bitcoin-core implementation](https://github.com/bitcoin/bitcoin/pull/32080).
+The specifications of `OP_CHECKCONTRACTVERIFY` are available in [BIP 443](https://github.com/bitcoin/bips/blob/master/bip-0443.mediawiki) and the [bitcoin-core implementation](https://github.com/bitcoin/bitcoin/pull/32080).
 
 These specifications are only for the `OP_CCV` opcode, and therefore should be paired with an opcode for vector commitments for a complete proposal for MATT [as originally proposed](https://lists.linuxfoundation.org/pipermail/bitcoin-dev/2022-November/021182.html).
 

--- a/content/proposals/op_vault.md
+++ b/content/proposals/op_vault.md
@@ -10,6 +10,10 @@ toc = true
 +++
 
 
+> **Note:** BIP 345 (OP\_VAULT) was withdrawn on May 8, 2025, superseded by BIP 443
+> (OP\_CHECKCONTRACTVERIFY). See the [CCV/MATT proposal](/proposals/matt/) for the current
+> approach to vaults.
+
 ## Introduction
 
 This proposal proposes two new tapscript opcodes that add consensus support for a specialized
@@ -23,8 +27,8 @@ This proposal is explicitly aimed at enabling the [vaults](/use-cases/vaults) us
 
 ## Specification
 
-This proposal is being specified as
-[BIP-345](https://github.com/bitcoin/bips/pull/1421).
+This proposal was specified as
+[BIP 345](https://github.com/bitcoin/bips/blob/master/bip-0345.mediawiki).
 
 A [draft implementation](https://github.com/bitcoin-inquisition/bitcoin/pull/21) has been made for
 Bitcoin Inquisition.

--- a/content/proposals/txhash.md
+++ b/content/proposals/txhash.md
@@ -37,8 +37,7 @@ checking of input and output values or scriptPubkeys.
 
 ## Specification
 
-A BIP of the opcodes in this proposal is currently [in draft status on
-GitHub](https://github.com/bitcoin/bips/pull/1500).
+The opcodes in this proposal are specified in [BIP 346](https://github.com/bitcoin/bips/blob/master/bip-0346.mediawiki).
 
 ### Potential Extensions
 

--- a/content/use-cases/dlcs.md
+++ b/content/use-cases/dlcs.md
@@ -51,7 +51,7 @@ original counterparty, significantly improving the liquidity and utility of DLCs
 
 Covenant proposals that enable recursive covenants, such as [CAT](/extra/CAT) and
 [CCV](/proposals/matt) (when combined with
-[PAIRCOMMIT](https://github.com/bitcoin/bips/blob/018d28c967b3f2b747ecb4e5a85d0b5f9f4ec79a/bip-PC.md)),
+[PAIRCOMMIT](https://github.com/bitcoin/bips/blob/master/bip-0442.mediawiki)),
 allow for even more sophisticated DLC operations in addition to simplification and cost reduction of
 transferability:
 
@@ -77,10 +77,10 @@ DLCs. ([CAT](/extra/CAT) / [TXHASH](/proposals/txhash) / [CCV](/proposals/matt))
 - **Position Splitting**: Participants can divide their DLC position into smaller pieces, each
 backed by a proportional amount of the original collateral. ([CAT](/extra/CAT) /
 [CCV](/proposals/matt) +
-[PAIRCOMMIT](https://github.com/bitcoin/bips/blob/018d28c967b3f2b747ecb4e5a85d0b5f9f4ec79a/bip-PC.md))
+[PAIRCOMMIT](https://github.com/bitcoin/bips/blob/master/bip-0442.mediawiki))
 - **Collateral Management**: Enables committing to rules for adding or adjusting collateral.
 ([CAT](/extra/CAT) / [CCV](/proposals/matt) +
-[PAIRCOMMIT](https://github.com/bitcoin/bips/blob/018d28c967b3f2b747ecb4e5a85d0b5f9f4ec79a/bip-PC.md))
+[PAIRCOMMIT](https://github.com/bitcoin/bips/blob/master/bip-0442.mediawiki))
 
 ## Trade-offs
 

--- a/templates/docs/page.html
+++ b/templates/docs/page.html
@@ -11,21 +11,23 @@
 {% endblock header %}
 
 {% block content %}
-{% set landing = "overview/introduction" %}
-{% set page = get_page(path = landing ~ ".md") %}
 <div class="wrap container" role="document">
   <div class="content">
     <div class="row flex-xl-nowrap">
 	  {{ macros_sidebar::docs_sidebar(current_section=current_section) }}
+	  {{ macros_toc::docs_toc(page=page) }}
       <main class="docs-content col-lg-11 col-xl-9">
         <h1>{{ page.title }}</h1>
+        {% if page.extra.lead %}<p class="lead">{{ page.extra.lead | safe }}</p>{% endif %}
         {{ page.content | safe }}
         {% if config.extra.edit_page %}
-          {{ macros_edit_page::docs_edit_page(current_path = "/" ~ landing, page=page) }}
+          {{ macros_edit_page::docs_edit_page(current_path=current_path, page=page) }}
+        {% endif %}
+        {% if config.extra.navigation %}
+          {{ macros_navigation::docs_navigation(page=page, current_section=current_section) }}
         {% endif %}
       </main>
     </div>
   </div>
 </div>
 {% endblock content %}
-

--- a/templates/macros/docs-edit-page.html
+++ b/templates/macros/docs-edit-page.html
@@ -1,0 +1,7 @@
+{% macro docs_edit_page(current_path, page) %}
+{% if page %}
+<p class="edit-page"><a href="{{ config.extra.docs_repo }}/blob/{{ config.extra.repo_branch }}/content/{{ page.relative_path | replace(from="\\", to="/") }}"><svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="feather feather-edit-2"><path d="M17 3a2.828 2.828 0 1 1 4 4L7.5 20.5 2 22l1.5-5.5L17 3z"></path></svg>Edit this page on GitHub</a></p>
+{% else %}
+<p class="edit-page"><a href="{{ config.extra.docs_repo }}/blob/{{ config.extra.repo_branch }}/content{{ current_path | replace(from="\\", to="/") | trim_end_matches(pat="/") }}.md"><svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="feather feather-edit-2"><path d="M17 3a2.828 2.828 0 1 1 4 4L7.5 20.5 2 22l1.5-5.5L17 3z"></path></svg>Edit this page on GitHub</a></p>
+{% endif %}
+{% endmacro %}


### PR DESCRIPTION
Update outdated proposal references across the site. BIP 443 (CCV/MATT), BIP 347 (OP_CAT), BIP 346 (TXHASH), and BIP 348 (CSFS) have all been merged. BIP 345 (OP_VAULT) was withdrawn in May 2025. Also fixes stale PAIRCOMMIT links and addresses #37.

### Changes

**BIP reference updates:**
- **MATT/CCV**: "BIP draft" / PR #1793 → BIP 443 (`bip-0443.mediawiki`)
- **TXHASH**: "draft BIP" / PR #1500 → BIP 346 (`bip-0346.mediawiki`)
- **OP_CAT**: "draft status" / PR #1525 → BIP 347 (`bip-0347.mediawiki`)
- **OP_CHECKSIGFROMSTACK**: "no BIP yet" → BIP 348 (`bip-0348.mediawiki`)
- **OP_VAULT**: added withdrawal notice, updated BIP 345 link to merged version
- **PAIRCOMMIT**: fixed stale links from old branch commit hash to `bip-0442.mediawiki`

**Updated files:** `summary.md`, `matt.md`, `cat.md`, `txhash.md`, `catt.md`, `op_vault.md`, `dlcs.md`

**Fix #37:** Override `docs-edit-page.html` macro to use `page.relative_path` instead of `current_path`, which preserves underscores in filenames (e.g., `op_vault.md` instead of `op-vault.md`).

Closes #37